### PR TITLE
Cache fetched GIDs via chrome.storage.sync

### DIFF
--- a/src/upvoter.ts
+++ b/src/upvoter.ts
@@ -8,19 +8,27 @@
 import * as Asana from 'asana';
 
 import {
-  client, findGid, workspaceGidFetch, pullResult, formatTask,
+  chromeStorageSyncFetch, chromeStorageSyncStore, client, findGid, workspaceGidFetch,
+  pullResult, formatTask,
 } from './asana-typeahead';
 import { customFieldName, increment } from './config';
 import { logError } from './error';
 
 export const customFieldGidFetch: Promise<string> = (async () => {
   const workspaceGid = await workspaceGidFetch;
+
+  let customFieldGid = await chromeStorageSyncFetch('customFieldGid');
+  if (customFieldGid != null) {
+    return customFieldGid;
+  }
+
   const customFields = await client.customFields.getCustomFieldsForWorkspace(workspaceGid, {});
-  const customFieldGid = await findGid(customFields,
+  customFieldGid = await findGid(customFields,
     (customField) => customField.name === customFieldName);
   if (customFieldGid == null) {
     logError('Could not find custom field GID!');
   }
+  chromeStorageSyncStore('customFieldGid', customFieldGid);
 
   return customFieldGid;
 })();

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -8,6 +8,7 @@
     "128": "apiology-128x128.png"
   },
   "permissions": [
+    "storage"
   ],
   "omnibox": { "keyword": "uv" },
   "background": {


### PR DESCRIPTION
This should speed things up by avoiding an extra use of the Asana API when the extension is cold.