### PR TITLE
Add worktree-safe cookiecutter upgrader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,16 +108,4 @@ report-coverage-to-codecov: report-coverage ## use codecov.io for PR-scoped code
 cicoverage: report-coverage-to-codecov ## check code coverage, then report to codecov
 
 update_from_cookiecutter: ## Bring in changes from template project used to create this repo
-	bundle exec overcommit --uninstall
-	cookiecutter_project_upgrader --help >/dev/null
-	IN_COOKIECUTTER_PROJECT_UPGRADER=1 cookiecutter_project_upgrader || true
-	git checkout cookiecutter-template && git push && git checkout main
-	git checkout main && git pull && git checkout -b update-from-cookiecutter-$$(date +%Y-%m-%d-%H%M)
-	git merge cookiecutter-template || true
-	bundle exec overcommit --install || true
-	@echo
-	@echo "Please resolve any merge conflicts below and push up a PR with:"
-	@echo
-	@echo '   gh pr create --title "Update from cookiecutter" --body "Automated PR to update from cookiecutter boilerplate"'
-	@echo
-	@echo
+	bin/cookiecutter_project_upgrader.sh


### PR DESCRIPTION
## Summary
- Makefile `update_from_cookiecutter` now delegates to `bin/cookiecutter_project_upgrader.sh`
- Script includes linked-worktree `.git` gitdir pointer shim (`.make/git-worktree-pointer`)

## Test plan
- [ ] `bin/test_git_worktree_upgrader.sh` passes
- [ ] `make update_from_cookiecutter` works in a git worktree